### PR TITLE
feat: FastAPI CORS 설정 추가 (#75)

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -48,3 +48,25 @@ REDIS_PORT=6379
 # 개발: bezero_redis_dev_password, 프로덕션: 강력한 비밀번호로 변경
 REDIS_PASSWORD=bezero_redis_dev_password
 REDIS_URL="redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}/0"
+
+# ======================
+# CORS Settings
+# ======================
+# CORS 허용 출처 (origins) - 프론트엔드 URL
+# 개발 환경: http://localhost:5173
+# 배포 환경: https://app.basementzero.cloud
+# 다중 출처 설정 시 쉼표로 구분: "http://localhost:5173,https://app.basementzero.cloud"
+CORS_ORIGINS=http://localhost:5173
+
+# CORS 허용 메서드 (쉼표로 구분 또는 *)
+# 기본값: * (모든 메서드 허용)
+CORS_ALLOW_METHODS=*
+
+# CORS 허용 헤더 (쉼표로 구분 또는 *)
+# 기본값: * (모든 헤더 허용)
+CORS_ALLOW_HEADERS=*
+
+# 자격 증명(쿠키, 인증 헤더) 허용 여부
+# true: 쿠키와 인증 헤더를 포함한 요청 허용
+# false: 쿠키와 인증 헤더를 포함한 요청 거부
+CORS_ALLOW_CREDENTIALS=true

--- a/src/bzero/core/config.py
+++ b/src/bzero/core/config.py
@@ -1,0 +1,86 @@
+"""
+B0 API 설정 모듈
+
+환경 변수를 기반으로 애플리케이션 설정을 관리합니다.
+"""
+
+import os
+from typing import Any
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """애플리케이션 설정 클래스"""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="allow",
+    )
+
+    # ======================
+    # Application Settings
+    # ======================
+    app_name: str = "B0 API"
+    app_version: str = "0.1.0"
+    debug: bool = True
+    environment: str = "local"  # local, production
+
+    # ======================
+    # CORS Settings
+    # ======================
+    # CORS 허용 출처 (origins)
+    # 개발 환경: http://localhost:5173
+    # 배포 환경: https://app.basementzero.cloud
+    # 여러 개를 설정할 경우 쉼표로 구분 (예: "http://localhost:5173,https://app.basementzero.cloud")
+    cors_origins: str = "http://localhost:5173"
+
+    # CORS 허용 메서드 (쉼표로 구분)
+    cors_allow_methods: str = "*"
+
+    # CORS 허용 헤더 (쉼표로 구분)
+    cors_allow_headers: str = "*"
+
+    # 자격 증명(쿠키, 인증 헤더 등) 허용 여부
+    # True로 설정 시, credentials를 포함한 요청 허용
+    cors_allow_credentials: bool = True
+
+    def get_cors_origins(self) -> list[str]:
+        """
+        CORS 허용 출처 리스트 반환
+
+        환경 변수에서 쉼표로 구분된 문자열을 파싱하여
+        리스트로 변환합니다.
+
+        Returns:
+            허용된 출처(origin) URL 리스트
+        """
+        return [origin.strip() for origin in self.cors_origins.split(",") if origin.strip()]
+
+    def get_cors_allow_methods(self) -> list[str]:
+        """
+        CORS 허용 메서드 리스트 반환
+
+        Returns:
+            허용된 HTTP 메서드 리스트 또는 ["*"]
+        """
+        if self.cors_allow_methods == "*":
+            return ["*"]
+        return [method.strip() for method in self.cors_allow_methods.split(",") if method.strip()]
+
+    def get_cors_allow_headers(self) -> list[str]:
+        """
+        CORS 허용 헤더 리스트 반환
+
+        Returns:
+            허용된 HTTP 헤더 리스트 또는 ["*"]
+        """
+        if self.cors_allow_headers == "*":
+            return ["*"]
+        return [header.strip() for header in self.cors_allow_headers.split(",") if header.strip()]
+
+
+# 전역 설정 인스턴스
+settings = Settings()

--- a/src/bzero/main.py
+++ b/src/bzero/main.py
@@ -1,8 +1,31 @@
 import uvicorn
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
+from bzero.core.config import settings
 
 app = FastAPI()
+
+# ======================
+# CORS 설정
+# ======================
+# Cross-Origin Resource Sharing (CORS) 미들웨어 설정
+# 프론트엔드에서 백엔드 API에 접근할 수 있도록 허용합니다.
+#
+# 개발 환경: http://localhost:5173 (Vite 개발 서버)
+# 배포 환경: https://app.basementzero.cloud (Cloudflare Pages)
+#
+# 환경별 설정 방법:
+# - 개발: CORS_ORIGINS="http://localhost:5173"
+# - 배포: CORS_ORIGINS="https://app.basementzero.cloud"
+# - 다중 출처: CORS_ORIGINS="http://localhost:5173,https://app.basementzero.cloud"
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.get_cors_origins(),  # 허용할 출처(origin) 리스트
+    allow_credentials=settings.cors_allow_credentials,  # 쿠키 등 자격증명 허용
+    allow_methods=settings.get_cors_allow_methods(),  # 허용할 HTTP 메서드
+    allow_headers=settings.get_cors_allow_headers(),  # 허용할 HTTP 헤더
+)
 
 
 @app.get("/")


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Cloudflare Pages 프론트엔드와의 통신을 위해 FastAPI에 CORS(Cross-Origin Resource Sharing) 설정을 추가했습니다.

## 주요 변경사항

### 1. CORS 설정 관리 클래스 추가 (`src/bzero/core/config.py`)
- `Settings` 클래스에 CORS 관련 설정 필드 추가
- 환경 변수 기반 CORS 설정 관리
- 쉼표로 구분된 출처(origins), 메서드, 헤더 파싱 메서드 구현

### 2. CORS 미들웨어 적용 (`src/bzero/main.py`)
- `CORSMiddleware` 추가
- 허용된 출처, 메서드, 헤더, 자격증명 설정

### 3. 환경 변수 템플릿 업데이트 (`.env.template`)
- `CORS_ORIGINS`: 허용할 출처 (기본값: `http://localhost:5173`)
- `CORS_ALLOW_METHODS`: 허용할 HTTP 메서드 (기본값: `*`)
- `CORS_ALLOW_HEADERS`: 허용할 HTTP 헤더 (기본값: `*`)
- `CORS_ALLOW_CREDENTIALS`: 자격증명 허용 여부 (기본값: `true`)

## 환경별 설정 예시

### 개발 환경
```env
CORS_ORIGINS=http://localhost:5173
```

### 배포 환경
```env
CORS_ORIGINS=https://app.basementzero.cloud
```

### 다중 출처 설정
```env
CORS_ORIGINS=http://localhost:5173,https://app.basementzero.cloud
```

## Test plan

- [ ] 로컬 환경에서 Vite 개발 서버(`http://localhost:5173`)로부터의 API 요청 테스트
- [ ] Cloudflare Pages 배포 후 프로덕션 URL로부터의 API 요청 테스트
- [ ] CORS preflight 요청(OPTIONS) 정상 작동 확인
- [ ] 자격증명(쿠키, Authorization 헤더) 포함 요청 테스트

## Related Issue

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)