### PR TITLE
feat: FastAPI CORS 설정 추가

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -47,10 +47,10 @@ REDIS__PASSWORD=bezero_redis_dev_password
 # CORS Settings
 # ======================
 # CORS 허용 출처 (origins) - 프론트엔드 URL
-# 개발 환경: http://localhost:5173
-# 배포 환경: https://app.basementzero.cloud
-# 다중 출처 설정 시 json array 로 표시: '["http://localhost:5173","https://app.basementzero.cloud"]'
-CORS__ORIGINS='["http://localhost:5173"]'
+# 개발 환경: http://localhost:5173 (Vite 개발 서버)
+# 배포 환경: https://app.basementzero.cloud (Cloudflare Pages)
+# 다중 출처 설정 예시: '["http://localhost:5173","https://app.basementzero.cloud"]'
+CORS__ORIGINS='["http://localhost:5173","https://app.basementzero.cloud"]'
 CORS__ALLOW_METHODS='["*"]'
 CORS__ALLOW_HEADERS='["*"]'
 # 자격 증명(쿠키, 인증 헤더) 허용 여부

--- a/src/bzero/main.py
+++ b/src/bzero/main.py
@@ -1,5 +1,6 @@
 import uvicorn
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from bzero.core.loggers import setup_loggers
 from bzero.core.settings import Environment, get_settings
@@ -10,6 +11,15 @@ def create_app() -> FastAPI:
     settings = get_settings()
 
     b0 = FastAPI(title=settings.app_name, version=settings.app_version, debug=settings.is_debug)
+
+    # CORS 설정
+    b0.add_middleware(
+        CORSMiddleware,
+        allow_origins=settings.cors.origins,
+        allow_credentials=settings.cors.allow_credentials,
+        allow_methods=settings.cors.allow_methods,
+        allow_headers=settings.cors.allow_headers,
+    )
 
     if settings.environment != Environment.TEST:
         # 테스트 때는 로깅 X


### PR DESCRIPTION
## Summary
Cloudflare Pages 프론트엔드와 Railway FastAPI 백엔드 간 통신을 위한 CORS 설정을 추가했습니다.

## 변경사항
- `src/bzero/main.py`: CORSMiddleware 추가
  - `settings.cors`에서 설정값 로드
  - allow_origins, allow_credentials, allow_methods, allow_headers 설정
- `.env.template`: CORS 환경 변수 업데이트
  - 개발 환경: `http://localhost:5173` (Vite)
  - 배포 환경: `https://app.basementzero.cloud` (Cloudflare Pages)
  - 두 URL을 모두 포함하도록 기본값 설정

## 기술 스택
- FastAPI CORSMiddleware
- Pydantic Settings (기존 `CorsSettings` 활용)

## 테스트 계획
- [ ] 로컬 개발 서버에서 프론트엔드 연결 테스트 (http://localhost:5173)
- [ ] Railway 배포 후 Cloudflare Pages와 통신 테스트
- [ ] CORS preflight 요청 확인 (OPTIONS 메서드)
- [ ] 인증 헤더 포함 요청 테스트

Resolves #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)