### PR TITLE
fix: EXTENDED 상태의 룸 스테이도 활성 체류로 조회되도록 수정

### DIFF
--- a/src/bzero/infrastructure/repositories/room_stay_core.py
+++ b/src/bzero/infrastructure/repositories/room_stay_core.py
@@ -45,7 +45,7 @@ class RoomStayRepositoryCore:
         """사용자의 체크인된 룸 스테이를 조회하는 쿼리를 생성합니다."""
         return select(RoomStayModel).where(
             RoomStayModel.user_id == user_id.value,
-            RoomStayModel.status == RoomStayStatus.CHECKED_IN.value,
+            RoomStayModel.status != RoomStayStatus.CHECKED_OUT.value,
             RoomStayModel.deleted_at.is_(None),
         )
 
@@ -56,7 +56,7 @@ class RoomStayRepositoryCore:
         """룸의 체크인된 모든 룸 스테이를 조회하는 쿼리를 생성합니다."""
         return select(RoomStayModel).where(
             RoomStayModel.room_id == room_id.value,
-            RoomStayModel.status == RoomStayStatus.CHECKED_IN.value,
+            RoomStayModel.status != RoomStayStatus.CHECKED_OUT.value,
             RoomStayModel.deleted_at.is_(None),
         )
 
@@ -75,7 +75,7 @@ class RoomStayRepositoryCore:
         """체크아웃 예정 시간이 지난 룸 스테이를 조회하는 쿼리를 생성합니다."""
         return select(RoomStayModel).where(
             RoomStayModel.scheduled_check_out_at < before,
-            RoomStayModel.status == RoomStayStatus.CHECKED_IN.value,
+            RoomStayModel.status != RoomStayStatus.CHECKED_OUT.value,
             RoomStayModel.deleted_at.is_(None),
         )
 


### PR DESCRIPTION
## Summary

- EXTENDED(연장) 상태의 룸 스테이도 활성 체류로 조회되도록 버그 수정
- 3개의 쿼리에서 `status == CHECKED_IN` → `status != CHECKED_OUT`으로 변경
  - `_query_find_checked_in_by_user_id`
  - `_query_find_all_checked_in_by_room_id`
  - `_query_find_all_due_for_check_out`

## Changes

- `room_stay_core.py`: 활성 체류 조회 시 EXTENDED 상태도 포함하도록 수정
- Repository 통합 테스트: EXTENDED 상태 조회 테스트 추가
- E2E 테스트: EXTENDED 상태 API 조회 테스트 추가

## Test plan

- [x] Repository 통합 테스트 통과
- [x] E2E 테스트 통과
- [x] 린팅 및 포매팅 통과

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)