### PR TITLE
feat: /api/v1/airships 응답에 cost_factor, duration_factor 필드 추가

### DIFF
--- a/src/bzero/presentation/schemas/airship.py
+++ b/src/bzero/presentation/schemas/airship.py
@@ -12,6 +12,8 @@ class AirshipResponse(BaseModel):
     name: str = Field(..., description="비행선 이름")
     description: str = Field(..., description="비행선 설명")
     image_url: str | None = Field(None, description="비행선 이미지 URL")
+    cost_factor: int = Field(..., description="비용 배율")
+    duration_factor: int = Field(..., description="소요 시간 배율")
     created_at: datetime = Field(..., description="생성 일시")
     updated_at: datetime = Field(..., description="수정 일시")
 
@@ -30,6 +32,8 @@ class AirshipResponse(BaseModel):
             name=result.name,
             description=result.description,
             image_url=result.image_url,
+            cost_factor=result.cost_factor,
+            duration_factor=result.duration_factor,
             created_at=result.created_at,
             updated_at=result.updated_at,
         )

--- a/tests/e2e/presentation/api/test_airship_api.py
+++ b/tests/e2e/presentation/api/test_airship_api.py
@@ -111,6 +111,8 @@ class TestGetAvailableAirships:
         assert "name" in first_airship
         assert "description" in first_airship
         assert "image_url" in first_airship
+        assert "cost_factor" in first_airship
+        assert "duration_factor" in first_airship
         assert "created_at" in first_airship
         assert "updated_at" in first_airship
 
@@ -118,6 +120,8 @@ class TestGetAvailableAirships:
         assert first_airship["name"] == "일반 비행선"
         assert first_airship["description"] == "편안한 속도로 여행하는 일반 비행선입니다."
         assert first_airship["image_url"] == "https://example.com/normal_airship.jpg"
+        assert first_airship["cost_factor"] == 1
+        assert first_airship["duration_factor"] == 1
 
     async def test_get_available_airships_with_pagination(
         self, client: AsyncClient, sample_airships: list[AirshipModel]


### PR DESCRIPTION
## Summary
- `AirshipResponse` 스키마에 `cost_factor`, `duration_factor` 필드 추가
- `create_from` 메서드에서 해당 필드 매핑 추가
- E2E 테스트에 새 필드 검증 추가

## Test plan
- [x] E2E 테스트 통과 확인 (`tests/e2e/presentation/api/test_airship_api.py`)
- [x] 린팅 및 포매팅 통과 확인

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)