### PR TITLE
refactor: DM 모듈 UUID 처리 일관성 개선

### DIFF
--- a/src/bzero/application/results/dm.py
+++ b/src/bzero/application/results/dm.py
@@ -36,10 +36,10 @@ class DirectMessageResult:
     def create_from(cls, message: DirectMessage) -> "DirectMessageResult":
         """DirectMessage 엔티티로부터 Result를 생성합니다."""
         return cls(
-            dm_id=str(message.dm_id.value),
-            dm_room_id=str(message.dm_room_id.value),
-            from_user_id=str(message.from_user_id.value),
-            to_user_id=str(message.to_user_id.value),
+            dm_id=message.dm_id.to_hex(),
+            dm_room_id=message.dm_room_id.to_hex(),
+            from_user_id=message.from_user_id.to_hex(),
+            to_user_id=message.to_user_id.to_hex(),
             content=message.content.value,
             is_read=message.is_read,
             created_at=message.created_at,
@@ -87,11 +87,11 @@ class DirectMessageRoomResult:
     ) -> "DirectMessageRoomResult":
         """DirectMessageRoom 엔티티로부터 Result를 생성합니다."""
         return cls(
-            dm_room_id=str(dm_room.dm_room_id.value),
-            guesthouse_id=str(dm_room.guesthouse_id.value),
-            room_id=str(dm_room.room_id.value),
-            user1_id=str(dm_room.requester_id.value),
-            user2_id=str(dm_room.receiver_id.value),
+            dm_room_id=dm_room.dm_room_id.to_hex(),
+            guesthouse_id=dm_room.guesthouse_id.to_hex(),
+            room_id=dm_room.room_id.to_hex(),
+            user1_id=dm_room.requester_id.to_hex(),
+            user2_id=dm_room.receiver_id.to_hex(),
             status=str(dm_room.status.value),
             started_at=dm_room.started_at,
             ended_at=dm_room.ended_at,

--- a/src/bzero/domain/services/room_stay.py
+++ b/src/bzero/domain/services/room_stay.py
@@ -152,7 +152,10 @@ class NotificationService:
     async def create_checkout_reminder(self, user_id: Id, message: str) -> Notification:
         return await self._notification_repository.create(
             Notification.create(
-                user_id=user_id, notification_type=NotificationType.CHECKOUT_REMINDER, title="체크아웃 알림", message=message
+                user_id=user_id,
+                notification_type=NotificationType.CHECKOUT_REMINDER,
+                title="체크아웃 알림",
+                message=message,
             )
         )
 
@@ -234,6 +237,9 @@ class NotificationSyncService:
     def create_checkout_reminder(self, user_id: Id, message: str) -> Notification:
         return self._notification_repository.create(
             Notification.create(
-                user_id=user_id, notification_type=NotificationType.CHECKOUT_REMINDER, title="체크아웃 알림", message=message
+                user_id=user_id,
+                notification_type=NotificationType.CHECKOUT_REMINDER,
+                title="체크아웃 알림",
+                message=message,
             )
         )

--- a/src/bzero/presentation/api/room_stay.py
+++ b/src/bzero/presentation/api/room_stay.py
@@ -91,7 +91,9 @@ async def extend_current_stay(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Insufficient points") from e
     except (NoActiveStayError, InvalidStayStatusError) as e:
         # 락 획득 후 상태가 변경되었을 수 있음
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No active stay found or invalid status") from e
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="No active stay found or invalid status"
+        ) from e
     except ForbiddenRoomForUserError as e:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden") from e
 

--- a/src/bzero/presentation/socketio/dependencies.py
+++ b/src/bzero/presentation/socketio/dependencies.py
@@ -13,8 +13,6 @@ logger = logging.getLogger(__name__)
 sio = get_socketio_server()
 
 
-
-
 def socket_handler[T: BaseModel](schema: type[T] | None = None, namespace: str = "/"):
     """Socket.IO 핸들러를 위한 데코레이터.
 

--- a/tests/e2e/presentation/api/test_room_stay_api.py
+++ b/tests/e2e/presentation/api/test_room_stay_api.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 
 import pytest
@@ -18,7 +17,6 @@ class TestRoomStayAPI:
         DataResponse(data=None) 반환 가능.
         """
         # Given: Create User
-
 
         # We need to create a user that matches the auth_headers
         # auth_headers uses default provider_user_id="test-user-id-123", provider="email"

--- a/tests/integration/domain/repositories/test_direct_message_room_repository.py
+++ b/tests/integration/domain/repositories/test_direct_message_room_repository.py
@@ -4,7 +4,6 @@ from datetime import datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
-from uuid_utils import uuid7
 
 from bzero.domain.entities.direct_message_room import DirectMessageRoom
 from bzero.domain.value_objects import DMStatus, Id
@@ -28,7 +27,7 @@ async def sample_users(test_session: AsyncSession) -> tuple[UserModel, UserModel
     """테스트용 샘플 유저 2명 생성."""
     now = datetime.now()
     user1 = UserModel(
-        user_id=uuid7(),
+        user_id=Id().value,
         email="user1@example.com",
         nickname="유저1",
         profile_emoji="👤",
@@ -36,7 +35,7 @@ async def sample_users(test_session: AsyncSession) -> tuple[UserModel, UserModel
         created_at=now,
     )
     user2 = UserModel(
-        user_id=uuid7(),
+        user_id=Id().value,
         email="user2@example.com",
         nickname="유저2",
         profile_emoji="👥",
@@ -55,7 +54,7 @@ async def sample_room(test_session: AsyncSession) -> RoomModel:
 
     # Create a city
     city = CityModel(
-        city_id=uuid7(),
+        city_id=Id().value,
         name="테스트 도시",
         theme="테스트",
         description="테스트용 도시",
@@ -69,7 +68,7 @@ async def sample_room(test_session: AsyncSession) -> RoomModel:
 
     # Create a guest house
     guest_house = GuestHouseModel(
-        guest_house_id=uuid7(),
+        guest_house_id=Id().value,
         city_id=city.city_id,
         name="테스트 게스트하우스",
         guest_house_type="WANDERER",
@@ -79,7 +78,7 @@ async def sample_room(test_session: AsyncSession) -> RoomModel:
 
     # Create a room
     room = RoomModel(
-        room_id=uuid7(),
+        room_id=Id().value,
         guest_house_id=guest_house.guest_house_id,
         max_capacity=10,
         current_capacity=0,
@@ -214,7 +213,7 @@ class TestDirectMessageRoomRepository:
 
         # Create additional users for different DM rooms
         user3 = UserModel(
-            user_id=uuid7(),
+            user_id=Id().value,
             email="user3@example.com",
             nickname="유저3",
             profile_emoji="👩",


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
DirectMessage 관련 코드에서 UUID 처리 방식을 프로젝트 표준에 맞게 개선했습니다.

### 주요 변경사항
- **Application Layer (Results)**:
  - `DirectMessageResult.create_from()`: `str(id.value)` → `id.to_hex()` 변경
  - `DirectMessageRoomResult.create_from()`: `str(id.value)` → `id.to_hex()` 변경

- **Test Layer**:
  - 테스트 픽스처에서 `uuid7()` 직접 호출 → `Id().value` 사용으로 변경
  - `sample_users`, `sample_room` 픽스처에서 일관된 Id 값 객체 활용

### 개선 효과
- 도메인 계층의 `Id` 값 객체를 활용하여 코드 일관성 향상
- UUID를 hex string으로 변환 시 표준 메서드(`.to_hex()`) 사용
- 테스트 코드에서도 도메인 값 객체 패턴 준수

## Test plan
- [x] 기존 테스트 통과 확인
- [x] Ruff 린팅 통과
- [x] 코드 일관성 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)