### PR TITLE
feat: 비활성화된 도시 조회 기능 추가

### DIFF
--- a/src/bzero/application/use_cases/cities/__init__.py
+++ b/src/bzero/application/use_cases/cities/__init__.py
@@ -1,10 +1,10 @@
-from bzero.application.use_cases.cities.get_active_cities import (
-    GetActiveCitiesUseCase,
+from bzero.application.use_cases.cities.get_cities import (
+    GetCitiesUseCase,
 )
 from bzero.application.use_cases.cities.get_city_by_id import GetCityByIdUseCase
 
 
 __all__ = [
-    "GetActiveCitiesUseCase",
+    "GetCitiesUseCase",
     "GetCityByIdUseCase",
 ]

--- a/src/bzero/application/use_cases/cities/get_cities.py
+++ b/src/bzero/application/use_cases/cities/get_cities.py
@@ -3,25 +3,26 @@ from bzero.application.results.common import PaginatedResult
 from bzero.domain.services.city import CityService
 
 
-class GetActiveCitiesUseCase:
+class GetCitiesUseCase:
     """
-    활성화된 도시 목록 조회 UseCase
+    도시 목록 조회 UseCase
 
-    display_order 순서대로 정렬된 활성화된 도시 목록을 조회합니다.
+    display_order 순서대로 정렬된 도시 목록을 조회합니다.
     """
 
     def __init__(self, city_service: CityService):
         self._city_service = city_service
 
-    async def execute(self, offset: int = 0, limit: int = 20) -> PaginatedResult[CityResult]:
+    async def execute(self, offset: int = 0, limit: int = 20, active_only: bool = True) -> PaginatedResult[CityResult]:
         """
         Args:
             offset: 조회 시작 위치 (기본값: 0)
             limit: 조회할 최대 개수 (기본값: 20)
+            active_only: 활성화된 도시만 조회할지 여부 (기본값: True)
 
         Returns:
-            활성화된 도시 목록 및 pagination 정보
+            도시 목록 및 pagination 정보
         """
-        cities, total = await self._city_service.get_active_cities(offset, limit)
+        cities, total = await self._city_service.get_cities(offset, limit, active_only)
         city_results = [CityResult.create_from(city) for city in cities]
         return PaginatedResult(items=city_results, total=total, offset=offset, limit=limit)

--- a/src/bzero/domain/repositories/city.py
+++ b/src/bzero/domain/repositories/city.py
@@ -30,23 +30,27 @@ class CityRepository(ABC):
         """
 
     @abstractmethod
-    async def find_active_cities(self, offset: int = 0, limit: int = 20) -> list[City]:
-        """활성화된 도시 목록을 조회합니다.
+    async def find_cities(self, offset: int = 0, limit: int = 20, active_only: bool = True) -> list[City]:
+        """도시 목록을 조회합니다.
 
         display_order 순서대로 정렬하여 반환합니다.
 
         Args:
             offset: 조회 시작 위치 (기본값: 0)
             limit: 조회할 최대 개수 (기본값: 20)
+            active_only: 활성화된 도시만 조회할지 여부 (기본값: True)
 
         Returns:
-            활성화된 도시 목록 (display_order 오름차순)
+            도시 목록 (display_order 오름차순)
         """
 
     @abstractmethod
-    async def count_active_cities(self) -> int:
-        """활성화된 도시의 총 개수를 조회합니다.
+    async def count_cities(self, active_only: bool = True) -> int:
+        """도시의 총 개수를 조회합니다.
+
+        Args:
+            active_only: 활성화된 도시만 카운트할지 여부 (기본값: True)
 
         Returns:
-            활성화된 도시의 총 개수
+            도시의 총 개수
         """

--- a/src/bzero/domain/services/city.py
+++ b/src/bzero/domain/services/city.py
@@ -14,20 +14,26 @@ class CityService:
     def __init__(self, city_repository: CityRepository):
         self._city_repository = city_repository
 
-    async def get_active_cities(self, offset: int = 0, limit: int = 20) -> tuple[list[City], int]:
-        """활성화된 도시 목록을 조회합니다.
+    async def get_cities(
+        self,
+        offset: int = 0,
+        limit: int = 20,
+        active_only: bool = True,
+    ) -> tuple[list[City], int]:
+        """도시 목록을 조회합니다.
 
         display_order 순서대로 정렬하여 반환합니다.
 
         Args:
             offset: 조회 시작 위치 (기본값: 0)
             limit: 조회할 최대 개수 (기본값: 20)
+            active_only: 활성화된 도시만 조회할지 여부 (기본값: True)
 
         Returns:
-            (활성화된 도시 목록, 전체 개수) 튜플
+            (도시 목록, 전체 개수) 튜플
         """
-        cities = await self._city_repository.find_active_cities(offset, limit)
-        total = await self._city_repository.count_active_cities()
+        cities = await self._city_repository.find_cities(offset, limit, active_only)
+        total = await self._city_repository.count_cities(active_only)
         return cities, total
 
     async def get_city_by_id(self, city_id: Id) -> City:

--- a/src/bzero/infrastructure/repositories/city.py
+++ b/src/bzero/infrastructure/repositories/city.py
@@ -28,31 +28,25 @@ class SqlAlchemyCityRepository(CityRepository):
         model = result.scalar_one_or_none()
         return self._to_entity(model) if model else None
 
-    async def find_active_cities(self, offset: int = 0, limit: int = 20) -> list[City]:
-        stmt = (
-            select(CityModel)
-            .where(
-                CityModel.is_active.is_(True),
-                CityModel.deleted_at.is_(None),
-            )
-            .order_by(CityModel.display_order.asc())
-            .offset(offset)
-            .limit(limit)
-        )
-        result = await self._session.execute(stmt)
+    async def find_cities(self, offset: int = 0, limit: int = 20, active_only: bool = True) -> list[City]:
+        query = select(CityModel).where(CityModel.deleted_at.is_(None))
+
+        if active_only:
+            query = query.where(CityModel.is_active.is_(True))
+
+        query = query.order_by(CityModel.display_order.asc()).offset(offset).limit(limit)
+
+        result = await self._session.execute(query)
         models = result.scalars().all()
         return [self._to_entity(model) for model in models]
 
-    async def count_active_cities(self) -> int:
-        stmt = (
-            select(func.count())
-            .select_from(CityModel)
-            .where(
-                CityModel.is_active.is_(True),
-                CityModel.deleted_at.is_(None),
-            )
-        )
-        result = await self._session.execute(stmt)
+    async def count_cities(self, active_only: bool = True) -> int:
+        query = select(func.count()).select_from(CityModel).where(CityModel.deleted_at.is_(None))
+
+        if active_only:
+            query = query.where(CityModel.is_active.is_(True))
+
+        result = await self._session.execute(query)
         return result.scalar_one()
 
     @staticmethod

--- a/src/bzero/presentation/api/city.py
+++ b/src/bzero/presentation/api/city.py
@@ -4,8 +4,8 @@ from typing import Annotated
 
 from fastapi import APIRouter, Query
 
-from bzero.application.use_cases.cities.get_active_cities import (
-    GetActiveCitiesUseCase,
+from bzero.application.use_cases.cities.get_cities import (
+    GetCitiesUseCase,
 )
 from bzero.application.use_cases.cities.get_city_by_id import GetCityByIdUseCase
 from bzero.presentation.api.dependencies import CurrentCityService
@@ -19,21 +19,27 @@ router = APIRouter(prefix="/cities", tags=["cities"])
 @router.get(
     "",
     response_model=ListResponse[CityResponse],
-    summary="활성 도시 목록 조회",
-    description="활성화된 도시 목록을 display_order 순서대로 조회합니다.",
+    summary="도시 목록 조회",
+    description="도시 목록을 display_order 순서대로 조회합니다.",
 )
-async def get_active_cities(
+async def get_cities(
     city_service: CurrentCityService,
     offset: Annotated[int, Query(ge=0, description="조회 시작 위치")] = 0,
     limit: Annotated[int, Query(ge=1, le=100, description="조회할 최대 개수")] = 20,
+    include_inactive: Annotated[bool, Query(description="비활성화된 도시 포함 여부")] = False,
 ) -> ListResponse[CityResponse]:
-    """활성화된 도시 목록 조회.
+    """도시 목록 조회.
 
-    - is_active=True인 도시만 반환
+    - include_inactive=False(기본값): 활성화된 도시만 조회
+    - include_inactive=True: 비활성화된 도시 포함 조회
     - display_order 오름차순 정렬
-    - pagination 지원 (기본값: offset=0, limit=20)
+    - pagination 지원
     """
-    result = await GetActiveCitiesUseCase(city_service).execute(offset, limit)
+    result = await GetCitiesUseCase(city_service).execute(
+        offset=offset,
+        limit=limit,
+        active_only=not include_inactive,
+    )
     return ListResponse(
         list=[CityResponse.create_from(city) for city in result.items],
         pagination=Pagination(total=result.total, offset=result.offset, limit=result.limit),


### PR DESCRIPTION
📌 개요 (Summary)
기존에는 활성화된 도시만 조회할 수 있었으나, 비활성화된 도시(is_active=False)도 조회할 수 있도록 기능을 확장했습니다. 이를 위해 UseCase와 Repository의 인터페이스를 개선하고, API 엔드포인트에 필터링 옵션을 추가했습니다.

🛠️ 주요 변경 사항 (Changes)
1. Application Layer (UseCase 리팩토링)
GetActiveCitiesUseCase → 
GetCitiesUseCase
:
기존에는 활성 도시만 가져오는 UseCase였으나, 범용적인 
GetCitiesUseCase
로 변경했습니다.
active_only 파라미터를 추가하여 기본값은 True(활성 도시만 조회)로 유지하되, 필요에 따라 전체 도시를 조회할 수 있게 변경했습니다.
2. Domain & Infrastructure Layer
CityRepository
 & 
CityService
:
find_active_cities → 
find_cities
로 메서드명을 변경했습니다.
count_active_cities → 
count_cities
로 변경했습니다.
active_only (bool) 파라미터를 추가하여 쿼리 빌딩 시 is_active=True 조건을 동적으로 적용하도록 수정했습니다.
3. Presentation Layer (API)
GET /cities:
include_inactive (bool) 쿼리 파라미터를 추가했습니다. (Default: False)
include_inactive=True 요청 시 비활성화된 도시도 포함하여 반환합니다.
✅ 테스트 계획 (Verification Plan)
기본 조회 (활성 도시):
GET /cities 호출 시 기존과 동일하게 활성화된 도시만 나오는지 확인.
전체 조회 (비활성 포함):
GET /cities?include_inactive=true 호출 시 is_active=False인 도시도 포함되는지 확인.
정렬 확인:
display_order 순서대로 올바르게 정렬되어 반환되는지 확인.