### PR TITLE
fix: RoomSyncRepository에 decrease_capacity 메서드 추가

### DIFF
--- a/src/bzero/domain/repositories/room.py
+++ b/src/bzero/domain/repositories/room.py
@@ -118,3 +118,14 @@ class RoomSyncRepository(ABC):
         Returns:
             업데이트된 방 엔티티
         """
+
+    @abstractmethod
+    def decrease_capacity(self, room_id: Id) -> None:
+        """방의 현재 인원을 1 감소시킵니다 (Atomic Update).
+
+        DB 레벨에서 `current_capacity = current_capacity - 1` 연산을 수행하여
+        동시성을 보장합니다.
+
+        Args:
+            room_id: 방 ID
+        """

--- a/src/bzero/infrastructure/repositories/room.py
+++ b/src/bzero/infrastructure/repositories/room.py
@@ -61,3 +61,6 @@ class SqlAlchemyRoomSyncRepository(RoomSyncRepository):
 
     def update(self, room: Room) -> Room:
         return RoomRepositoryCore.update(self._session, room)
+
+    def decrease_capacity(self, room_id: Id) -> None:
+        RoomRepositoryCore.decrease_capacity(self._session, room_id)

--- a/tests/integration/domain/repositories/test_city_repository.py
+++ b/tests/integration/domain/repositories/test_city_repository.py
@@ -138,17 +138,17 @@ class TestCityRepositoryFindById:
         assert city is None
 
 
-class TestCityRepositoryFindActiveCities:
-    """CityRepository.find_active_cities() 메서드 테스트."""
+class TestCityRepositoryFindCities:
+    """CityRepository.find_cities() 메서드 테스트."""
 
-    async def test_find_active_cities(
+    async def test_find_cities_active_only(
         self,
         city_repository: SqlAlchemyCityRepository,
         sample_cities: list[CityModel],
     ):
         """활성화된 도시 목록을 조회할 수 있어야 합니다."""
         # When: 활성화된 도시 목록 조회
-        cities = await city_repository.find_active_cities()
+        cities = await city_repository.find_cities(active_only=True)
 
         # Then: 2개의 활성 도시가 조회됨 (세렌시아, 로렌시아)
         assert len(cities) == 2
@@ -156,75 +156,75 @@ class TestCityRepositoryFindActiveCities:
         assert cities[1].name == "로렌시아"
         assert all(city.is_active for city in cities)
 
-    async def test_find_active_cities_ordered_by_display_order(
+    async def test_find_cities_ordered_by_display_order(
         self,
         city_repository: SqlAlchemyCityRepository,
         sample_cities: list[CityModel],
     ):
-        """활성화된 도시는 display_order 순으로 정렬되어야 합니다."""
+        """도시는 display_order 순으로 정렬되어야 합니다."""
         # When: 활성화된 도시 목록 조회
-        cities = await city_repository.find_active_cities()
+        cities = await city_repository.find_cities(active_only=True)
 
         # Then: display_order 순으로 정렬됨
         assert cities[0].display_order == 1
         assert cities[1].display_order == 2
 
-    async def test_find_active_cities_with_pagination(
+    async def test_find_cities_with_pagination(
         self,
         city_repository: SqlAlchemyCityRepository,
         sample_cities: list[CityModel],
     ):
         """pagination 파라미터로 도시 목록을 조회할 수 있어야 합니다."""
         # When: offset=0, limit=1로 조회
-        cities = await city_repository.find_active_cities(offset=0, limit=1)
+        cities = await city_repository.find_cities(offset=0, limit=1, active_only=True)
 
         # Then: 1개만 조회됨
         assert len(cities) == 1
         assert cities[0].name == "세렌시아"
 
-    async def test_find_active_cities_with_offset(
+    async def test_find_cities_with_offset(
         self,
         city_repository: SqlAlchemyCityRepository,
         sample_cities: list[CityModel],
     ):
         """offset 파라미터로 시작 위치를 지정할 수 있어야 합니다."""
         # When: offset=1로 조회
-        cities = await city_repository.find_active_cities(offset=1, limit=10)
+        cities = await city_repository.find_cities(offset=1, limit=10, active_only=True)
 
         # Then: 두 번째 도시부터 조회됨
         assert len(cities) == 1
         assert cities[0].name == "로렌시아"
 
-    async def test_count_active_cities(
+    async def test_count_cities_active_only(
         self,
         city_repository: SqlAlchemyCityRepository,
         sample_cities: list[CityModel],
     ):
         """활성화된 도시의 총 개수를 조회할 수 있어야 합니다."""
         # When: 활성화된 도시 개수 조회
-        count = await city_repository.count_active_cities()
+        count = await city_repository.count_cities(active_only=True)
 
         # Then: 2개가 반환됨
         assert count == 2
 
-    async def test_find_active_cities_empty(
+    async def test_find_cities_empty(
         self,
         city_repository: SqlAlchemyCityRepository,
     ):
-        """활성화된 도시가 없으면 빈 리스트를 반환해야 합니다."""
-        # When: 활성화된 도시 목록 조회 (샘플 데이터 없음)
-        cities = await city_repository.find_active_cities()
+        """도시가 없으면 빈 리스트를 반환해야 합니다."""
+        # When: 도시 목록 조회 (샘플 데이터 없음)
+        cities = await city_repository.find_cities(active_only=True)
 
         # Then: 빈 리스트 반환
         assert cities == []
 
-    async def test_count_active_cities_empty(
+    async def test_count_cities_empty(
         self,
         city_repository: SqlAlchemyCityRepository,
     ):
-        """활성화된 도시가 없으면 0을 반환해야 합니다."""
-        # When: 활성화된 도시 개수 조회 (샘플 데이터 없음)
-        count = await city_repository.count_active_cities()
+        """도시가 없으면 0을 반환해야 합니다."""
+        # When: 도시 개수 조회 (샘플 데이터 없음)
+        count = await city_repository.count_cities(active_only=True)
 
         # Then: 0이 반환됨
         assert count == 0

--- a/tests/integration/domain/repositories/test_room_repository.py
+++ b/tests/integration/domain/repositories/test_room_repository.py
@@ -569,3 +569,97 @@ class TestRoomSyncRepositoryUpdate:
         # When/Then: NotFoundRoomError 발생
         with pytest.raises(NotFoundRoomError):
             room_sync_repository.update(non_existent_room)
+
+
+class TestRoomSyncRepositoryDecreaseCapacity:
+    """RoomSyncRepository.decrease_capacity() 메서드 테스트."""
+
+    def test_decrease_capacity_success(
+        self,
+        room_sync_repository: SqlAlchemyRoomSyncRepository,
+        sample_guest_house_sync: GuestHouseModel,
+        test_sync_session: Session,
+    ):
+        """방 인원을 1 감소시킬 수 있어야 합니다."""
+        # Given: current_capacity가 3인 룸 생성
+        now = datetime.now()
+        room_model = RoomModel(
+            room_id=uuid7(),
+            guest_house_id=sample_guest_house_sync.guest_house_id,
+            max_capacity=6,
+            current_capacity=3,
+            created_at=now,
+            updated_at=now,
+        )
+        test_sync_session.add(room_model)
+        test_sync_session.flush()
+
+        room_id = Id(str(room_model.room_id))
+
+        # When: decrease_capacity 호출
+        room_sync_repository.decrease_capacity(room_id)
+        test_sync_session.flush()
+
+        # Then: current_capacity가 2로 감소
+        test_sync_session.refresh(room_model)
+        assert room_model.current_capacity == 2
+
+    def test_decrease_capacity_to_zero(
+        self,
+        room_sync_repository: SqlAlchemyRoomSyncRepository,
+        sample_guest_house_sync: GuestHouseModel,
+        test_sync_session: Session,
+    ):
+        """current_capacity가 1일 때 0으로 감소시킬 수 있어야 합니다."""
+        # Given: current_capacity가 1인 룸 생성
+        now = datetime.now()
+        room_model = RoomModel(
+            room_id=uuid7(),
+            guest_house_id=sample_guest_house_sync.guest_house_id,
+            max_capacity=6,
+            current_capacity=1,
+            created_at=now,
+            updated_at=now,
+        )
+        test_sync_session.add(room_model)
+        test_sync_session.flush()
+
+        room_id = Id(str(room_model.room_id))
+
+        # When: decrease_capacity 호출
+        room_sync_repository.decrease_capacity(room_id)
+        test_sync_session.flush()
+
+        # Then: current_capacity가 0으로 감소
+        test_sync_session.refresh(room_model)
+        assert room_model.current_capacity == 0
+
+    def test_decrease_capacity_does_not_go_negative(
+        self,
+        room_sync_repository: SqlAlchemyRoomSyncRepository,
+        sample_guest_house_sync: GuestHouseModel,
+        test_sync_session: Session,
+    ):
+        """current_capacity가 0일 때는 감소하지 않아야 합니다 (음수 방지)."""
+        # Given: current_capacity가 0인 룸 생성
+        now = datetime.now()
+        room_model = RoomModel(
+            room_id=uuid7(),
+            guest_house_id=sample_guest_house_sync.guest_house_id,
+            max_capacity=6,
+            current_capacity=0,
+            created_at=now,
+            updated_at=now,
+        )
+        test_sync_session.add(room_model)
+        test_sync_session.flush()
+
+        room_id = Id(str(room_model.room_id))
+
+        # When: decrease_capacity 호출
+        room_sync_repository.decrease_capacity(room_id)
+        test_sync_session.flush()
+
+        # Then: current_capacity가 0 유지 (음수로 가지 않음)
+        test_sync_session.refresh(room_model)
+        assert room_model.current_capacity == 0

--- a/tests/integration/domain/services/test_questionnaire_service.py
+++ b/tests/integration/domain/services/test_questionnaire_service.py
@@ -222,6 +222,7 @@ def sample_room_stay_entity(sample_room_stay_model: RoomStayModel) -> RoomStay:
         scheduled_check_out_at=sample_room_stay_model.scheduled_check_out_at,
         actual_check_out_at=sample_room_stay_model.actual_check_out_at,
         extension_count=sample_room_stay_model.extension_count or 0,
+        is_checkout_reminder_sent=sample_room_stay_model.is_checkout_reminder_sent or False,
         created_at=sample_room_stay_model.created_at,
         updated_at=sample_room_stay_model.updated_at,
     )

--- a/tests/integration/domain/services/test_room_stay_sync_service.py
+++ b/tests/integration/domain/services/test_room_stay_sync_service.py
@@ -16,6 +16,7 @@ from bzero.infrastructure.db.guest_house_model import GuestHouseModel
 from bzero.infrastructure.db.room_model import RoomModel
 from bzero.infrastructure.db.ticket_model import TicketModel
 from bzero.infrastructure.db.user_model import UserModel
+from bzero.infrastructure.repositories.room import SqlAlchemyRoomSyncRepository
 from bzero.infrastructure.repositories.room_stay import SqlAlchemyRoomStaySyncRepository
 
 
@@ -29,7 +30,8 @@ def timezone() -> ZoneInfo:
 def room_stay_sync_service(test_sync_session: Session, timezone: ZoneInfo) -> RoomStaySyncService:
     """RoomStaySyncService fixture를 생성합니다."""
     room_stay_repository = SqlAlchemyRoomStaySyncRepository(test_sync_session)
-    return RoomStaySyncService(room_stay_repository, timezone)
+    room_repository = SqlAlchemyRoomSyncRepository(test_sync_session)
+    return RoomStaySyncService(room_stay_repository, room_repository, timezone)
 
 
 @pytest.fixture

--- a/tests/unit/application/use_cases/test_chat_message_use_cases.py
+++ b/tests/unit/application/use_cases/test_chat_message_use_cases.py
@@ -6,7 +6,7 @@ from uuid_utils import uuid7
 
 from bzero.application.use_cases.chat_messages import GetMessageHistoryUseCase, SendMessageUseCase
 from bzero.domain.entities import ChatMessage, RoomStay
-from bzero.domain.services import ChatMessageService, RoomStayService
+from bzero.domain.services import ChatMessageService, RoomStayService, UserService
 from bzero.domain.value_objects import Id
 from bzero.domain.value_objects.chat_message import MessageContent, MessageType
 
@@ -31,19 +31,24 @@ def mock_room_stay_service():
     return service
 
 
+@pytest.fixture
+def mock_user_service():
+    return MagicMock(spec=UserService)
+
+
 class TestSendMessageUseCase:
     @pytest.mark.asyncio
-    async def test_execute_success(self, mock_session, mock_chat_message_service):
+    async def test_execute_success(self, mock_session, mock_chat_message_service, mock_user_service):
         # Given
-        use_case = SendMessageUseCase(mock_session, mock_chat_message_service)
-        user_id = str(uuid7().hex)
-        room_id = str(uuid7().hex)
+        use_case = SendMessageUseCase(mock_session, mock_chat_message_service, mock_user_service)
+        user_id = uuid7()
+        room_id = uuid7()
         content = "Hello, World!"
 
         expected_message = ChatMessage(
             message_id=Id(),
-            room_id=Id.from_hex(room_id),
-            user_id=Id.from_hex(user_id),
+            room_id=Id(room_id),
+            user_id=Id(user_id),
             content=MessageContent(content),
             card_id=None,
             message_type=MessageType.TEXT,
@@ -56,22 +61,33 @@ class TestSendMessageUseCase:
         mock_chat_message_service.send_message.return_value = expected_message
 
         # When
-        result = await use_case.execute(user_id, room_id, content)
+        result = await use_case.execute(
+            room_id=room_id.hex,
+            content=content,
+            user_id=user_id.hex,
+        )
 
         # Then
         assert result.content == content
-        assert result.user_id == user_id
+        assert result.user_id == user_id.hex
         mock_chat_message_service.send_message.assert_called_once()
         mock_session.commit.assert_called_once()
 
 
 class TestGetMessageHistoryUseCase:
     @pytest.mark.asyncio
-    async def test_execute_success(self, mock_chat_message_service, mock_room_stay_service):
+    async def test_execute_success(self, mock_chat_message_service, mock_room_stay_service, mock_user_service):
         # Given
-        use_case = GetMessageHistoryUseCase(mock_chat_message_service, mock_room_stay_service)
-        user_id = str(uuid7().hex)
-        room_id = str(uuid7().hex)
+        use_case = GetMessageHistoryUseCase(mock_user_service, mock_chat_message_service, mock_room_stay_service)
+        user_id = uuid7()
+        room_id = uuid7()
+        provider = "google"
+        provider_user_id = str(uuid7())
+
+        # Mock user lookup
+        mock_user = MagicMock()
+        mock_user.user_id = Id(user_id)
+        mock_user_service.find_user_by_provider_and_provider_user_id = AsyncMock(return_value=mock_user)
 
         # RoomStay check
         mock_room_stay_service.get_stays_by_user_id_and_room_id.return_value = [MagicMock(spec=RoomStay)]
@@ -80,8 +96,8 @@ class TestGetMessageHistoryUseCase:
         messages = [
             ChatMessage(
                 message_id=Id(),
-                room_id=Id.from_hex(room_id),
-                user_id=Id.from_hex(user_id),
+                room_id=Id(room_id),
+                user_id=Id(user_id),
                 content=MessageContent(f"Message {i}"),
                 card_id=None,
                 message_type=MessageType.TEXT,
@@ -96,9 +112,14 @@ class TestGetMessageHistoryUseCase:
         mock_chat_message_service.get_message_history.return_value = messages
 
         # When
-        results = await use_case.execute(user_id, room_id)
+        results = await use_case.execute(
+            provider=provider,
+            provider_user_id=provider_user_id,
+            room_id=room_id.hex,
+        )
 
         # Then
         assert len(results) == 3
+        mock_user_service.find_user_by_provider_and_provider_user_id.assert_called_once()
         mock_room_stay_service.get_stays_by_user_id_and_room_id.assert_called_once()
         mock_chat_message_service.get_message_history.assert_called_once()

--- a/tests/unit/application/use_cases/test_city_use_cases.py
+++ b/tests/unit/application/use_cases/test_city_use_cases.py
@@ -5,8 +5,8 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from bzero.application.use_cases.cities.get_active_cities import (
-    GetActiveCitiesUseCase,
+from bzero.application.use_cases.cities.get_cities import (
+    GetCitiesUseCase,
 )
 from bzero.application.use_cases.cities.get_city_by_id import GetCityByIdUseCase
 from bzero.domain.entities.city import City
@@ -73,14 +73,14 @@ def sample_cities():
     ]
 
 
-class TestGetActiveCitiesUseCase:
-    """GetActiveCitiesUseCase 테스트"""
+class TestGetCitiesUseCase:
+    """GetCitiesUseCase 테스트"""
 
     async def test_execute_returns_active_cities(self, mock_city_service, sample_cities):
         """활성 도시 목록을 반환한다"""
         # Given
-        mock_city_service.get_active_cities.return_value = (sample_cities, 2)
-        use_case = GetActiveCitiesUseCase(mock_city_service)
+        mock_city_service.get_cities.return_value = (sample_cities, 2)
+        use_case = GetCitiesUseCase(mock_city_service)
 
         # When
         result = await use_case.execute()
@@ -94,13 +94,13 @@ class TestGetActiveCitiesUseCase:
         assert result.total == 2
         assert result.offset == 0
         assert result.limit == 20
-        mock_city_service.get_active_cities.assert_called_once_with(0, 20)
+        mock_city_service.get_cities.assert_called_once_with(0, 20, True)
 
     async def test_execute_with_pagination(self, mock_city_service, sample_cities):
         """pagination 파라미터로 도시 목록을 조회한다"""
         # Given
-        mock_city_service.get_active_cities.return_value = (sample_cities[:1], 2)
-        use_case = GetActiveCitiesUseCase(mock_city_service)
+        mock_city_service.get_cities.return_value = (sample_cities[:1], 2)
+        use_case = GetCitiesUseCase(mock_city_service)
 
         # When
         result = await use_case.execute(offset=0, limit=1)
@@ -111,13 +111,13 @@ class TestGetActiveCitiesUseCase:
         assert result.total == 2
         assert result.offset == 0
         assert result.limit == 1
-        mock_city_service.get_active_cities.assert_called_once_with(0, 1)
+        mock_city_service.get_cities.assert_called_once_with(0, 1, True)
 
     async def test_execute_returns_empty_list_when_no_cities(self, mock_city_service):
         """활성 도시가 없을 때 빈 리스트를 반환한다"""
         # Given
-        mock_city_service.get_active_cities.return_value = ([], 0)
-        use_case = GetActiveCitiesUseCase(mock_city_service)
+        mock_city_service.get_cities.return_value = ([], 0)
+        use_case = GetCitiesUseCase(mock_city_service)
 
         # When
         result = await use_case.execute()
@@ -125,7 +125,7 @@ class TestGetActiveCitiesUseCase:
         # Then
         assert result.items == []
         assert result.total == 0
-        mock_city_service.get_active_cities.assert_called_once_with(0, 20)
+        mock_city_service.get_cities.assert_called_once_with(0, 20, True)
 
 
 class TestGetCityByIdUseCase:

--- a/tests/unit/domain/services/test_diary_service.py
+++ b/tests/unit/domain/services/test_diary_service.py
@@ -220,7 +220,7 @@ class TestDiaryServiceGetDiariesByUserId:
         assert total == 1
         assert diaries[0].user_id == sample_diary.user_id
         mock_diary_repository.find_all_by_user_id.assert_called_once_with(
-            user_id=sample_diary.user_id, limit=20, offset=0
+            user_id=sample_diary.user_id, limit=20, offset=0, room_stay_id=None
         )
         mock_diary_repository.count_by_user_id.assert_called_once_with(sample_diary.user_id)
 
@@ -241,7 +241,9 @@ class TestDiaryServiceGetDiariesByUserId:
         # Then
         assert len(diaries) == 0
         assert total == 50
-        mock_diary_repository.find_all_by_user_id.assert_called_once_with(user_id=user_id, limit=10, offset=20)
+        mock_diary_repository.find_all_by_user_id.assert_called_once_with(
+            user_id=user_id, limit=10, offset=20, room_stay_id=None
+        )
 
     async def test_get_diaries_by_user_id_returns_empty_list(
         self,

--- a/tests/unit/domain/services/test_questionnaire_service.py
+++ b/tests/unit/domain/services/test_questionnaire_service.py
@@ -209,7 +209,7 @@ class TestQuestionnaireServiceGetQuestionnairesByUserId:
         assert total == 1
         assert questionnaires[0].user_id == sample_questionnaire.user_id
         mock_questionnaire_repository.find_all_by_user_id.assert_called_once_with(
-            user_id=sample_questionnaire.user_id, limit=20, offset=0
+            user_id=sample_questionnaire.user_id, limit=20, offset=0, room_stay_id=None
         )
         mock_questionnaire_repository.count_by_user_id.assert_called_once_with(sample_questionnaire.user_id)
 
@@ -232,7 +232,9 @@ class TestQuestionnaireServiceGetQuestionnairesByUserId:
         # Then
         assert len(questionnaires) == 0
         assert total == 50
-        mock_questionnaire_repository.find_all_by_user_id.assert_called_once_with(user_id=user_id, limit=10, offset=20)
+        mock_questionnaire_repository.find_all_by_user_id.assert_called_once_with(
+            user_id=user_id, limit=10, offset=20, room_stay_id=None
+        )
 
     async def test_get_questionnaires_by_user_id_returns_empty_list(
         self,

--- a/tests/unit/domain/services/test_room_stay_service.py
+++ b/tests/unit/domain/services/test_room_stay_service.py
@@ -9,6 +9,7 @@ from uuid_utils import uuid7
 from bzero.core.settings import get_settings
 from bzero.domain.entities import Airship, City, Room, Ticket
 from bzero.domain.errors import InvalidTicketStatusError
+from bzero.domain.repositories.room import RoomSyncRepository
 from bzero.domain.repositories.room_stay import RoomStaySyncRepository
 from bzero.domain.services.room_stay import RoomStaySyncService
 from bzero.domain.value_objects import Id, TicketStatus
@@ -22,12 +23,19 @@ def mock_room_stay_repository() -> MagicMock:
 
 
 @pytest.fixture
+def mock_room_repository() -> MagicMock:
+    """Mock RoomSyncRepository"""
+    return MagicMock(spec=RoomSyncRepository)
+
+
+@pytest.fixture
 def room_stay_service(
     mock_room_stay_repository: MagicMock,
+    mock_room_repository: MagicMock,
 ) -> RoomStaySyncService:
     """RoomStaySyncService with mocked repositories"""
     timezone = get_settings().timezone
-    return RoomStaySyncService(mock_room_stay_repository, timezone)
+    return RoomStaySyncService(mock_room_stay_repository, mock_room_repository, timezone)
 
 
 @pytest.fixture

--- a/tests/unit/domain/services/test_stay_extension_service.py
+++ b/tests/unit/domain/services/test_stay_extension_service.py
@@ -43,9 +43,15 @@ def stay_extension_service(mock_room_stay_repository, mock_user_repository, mock
 
 
 @pytest.fixture
-def checkout_service(mock_room_stay_repository):
+def mock_room_repository():
+    return AsyncMock()
+
+
+@pytest.fixture
+def checkout_service(mock_room_stay_repository, mock_room_repository):
     return CheckoutService(
         room_stay_repository=mock_room_stay_repository,
+        room_repository=mock_room_repository,
         timezone=ZoneInfo("Asia/Seoul"),
     )
 


### PR DESCRIPTION
## Summary
- `RoomSyncRepository` 인터페이스에 `decrease_capacity` 추상 메서드 추가
- `SqlAlchemyRoomSyncRepository`에 구현체 추가 (RoomRepositoryCore 활용)
- 관련 통합 테스트 추가 및 기존 테스트 파일들의 outdated signature 수정

## 변경 내용

### 버그 수정 (Issue #148)
`task_auto_checkout_batch` Celery 태스크에서 `RoomStaySyncService.checkout_if_expired()` 호출 시 `SqlAlchemyRoomSyncRepository`에 `decrease_capacity` 메서드가 없어 발생하던 `AttributeError` 수정

### 테스트 수정
- `CityRepository`: `find_cities(active_only=True)` 사용
- `RoomStaySyncService`: `room_sync_repository` 파라미터 추가
- `CheckoutService`: `room_repository` 파라미터 추가
- `DiaryService`/`QuestionnaireService`: `room_stay_id` 파라미터 추가
- `SendMessageUseCase`/`GetMessageHistoryUseCase`: `user_service` 파라미터 추가
- `RoomStay`: `is_checkout_reminder_sent` 필드 추가

## Test plan
- [x] `uv run pytest` 실행하여 683개 테스트 통과 확인
- [x] Docker 환경에서 Celery worker 실행 후 자동 체크아웃 태스크 정상 동작 확인

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)