### PR TITLE
feat: Celery Worker에 Sentry 통합 추가

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "uuid-utils>=0.11.1",
     "uvicorn[standard]>=0.38.0",
     "flower>=2.0.1",
-    "sentry-sdk[fastapi]>=2.19.0",
+    "sentry-sdk[fastapi,celery]>=2.19.0",
 ]
 
 [project.scripts]

--- a/src/bzero/worker/app.py
+++ b/src/bzero/worker/app.py
@@ -10,6 +10,8 @@ Redis를 브로커와 결과 백엔드로 사용하며, 동기 DB 연결을 관�
 from celery import Celery
 from celery.schedules import crontab
 from celery.signals import worker_process_init, worker_process_shutdown
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
 
 from bzero.core.database import close_sync_db_connection, setup_sync_db_connection
 from bzero.core.loggers import background_logger, setup_loggers
@@ -37,6 +39,20 @@ def create_celery_app() -> Celery:
             "bzero.worker.tasks.tickets.task_complete_ticket",
         ],
     )
+
+    # Sentry 초기화 (Celery 설정)
+    if settings.sentry.dsn.get_secret_value():
+        sentry_sdk.init(
+            dsn=settings.sentry.dsn.get_secret_value(),
+            environment=settings.sentry.environment,
+            traces_sample_rate=settings.sentry.traces_sample_rate,
+            integrations=[
+                CeleryIntegration(
+                    monitor_beat_tasks=True,
+                    propagate_traces=True,
+                ),
+            ],
+        )
 
     celery_app.conf.update(
         # 타임존 설정

--- a/uv.lock
+++ b/uv.lock
@@ -234,7 +234,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-socketio" },
     { name = "redis" },
-    { name = "sentry-sdk", extra = ["fastapi"] },
+    { name = "sentry-sdk", extra = ["celery", "fastapi"] },
     { name = "sqlalchemy", extra = ["postgresql-asyncpg"] },
     { name = "uuid-utils" },
     { name = "uvicorn", extra = ["standard"] },
@@ -274,7 +274,7 @@ requires-dist = [
     { name = "python-socketio", extras = ["asyncio"], specifier = ">=5.11.0" },
     { name = "redis", specifier = ">=5.2.1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.3" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = ">=2.19.0" },
+    { name = "sentry-sdk", extras = ["fastapi", "celery"], specifier = ">=2.19.0" },
     { name = "sqlalchemy", extras = ["postgresql-asyncpg"], specifier = ">=2.0.44" },
     { name = "uuid-utils", specifier = ">=0.11.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.38.0" },
@@ -1477,6 +1477,9 @@ wheels = [
 ]
 
 [package.optional-dependencies]
+celery = [
+    { name = "celery" },
+]
 fastapi = [
     { name = "fastapi" },
 ]


### PR DESCRIPTION
## Summary

백그라운드 작업(Celery Task)에서 발생하는 에러도 Sentry로 추적할 수 있도록 Celery Worker에 Sentry를 통합했습니다.

**배경**: #153에서 FastAPI에 Sentry를 추가했지만, Celery Worker에서 발생하는 에러는 추적되지 않았습니다.  
**해결**: CeleryIntegration을 통해 백그라운드 작업의 에러와 성능도 모니터링할 수 있습니다.

---

## 주요 변경사항

### Dependencies
```diff
- "sentry-sdk[fastapi]>=2.19.0",
+ "sentry-sdk[fastapi,celery]>=2.19.0",
```

### Worker 설정
```python
# worker/app.py
sentry_sdk.init(
    dsn=settings.sentry.dsn.get_secret_value(),
    environment=settings.sentry.environment,
    traces_sample_rate=settings.sentry.traces_sample_rate,
    integrations=[
        CeleryIntegration(
            monitor_beat_tasks=True,  # Beat 스케줄 작업 모니터링
            propagate_traces=True,    # FastAPI → Celery 트레이스 전파
        ),
    ],
)
```

---

## Sentry Celery 주요 기능

### 🚨 에러 추적
- **자동 예외 캡처**: Celery Task에서 발생한 모든 예외 자동 보고
- **재시도 추적**: 작업 재시도 횟수 및 실패 원인 기록
- **컨텍스트 정보**: Task 이름, 인자, 실행 시간 등 상세 정보

### 📊 성능 모니터링
- **Task 실행 시간**: 각 작업의 평균/최대 실행 시간 측정
- **큐 대기 시간**: 작업이 큐에서 대기한 시간 추적
- **병목 지점 파악**: 느린 작업 자동 감지

### 🔗 분산 추적 (Distributed Tracing)
- **End-to-End 추적**: API 요청 → Celery 작업 전체 플로우 추적
- **예시**:
  ```
  1. POST /api/v1/tickets → PurchaseTicketUseCase
  2. TaskScheduler.schedule_ticket_completion()
  3. Celery Task: task_complete_ticket
  ```
  위 전체 플로우를 하나의 트레이스로 연결

### ⏰ Celery Beat 모니터링
- **스케줄 작업 추적**: Celery Beat로 예약된 작업 모니터링
- **실행 누락 감지**: 예정된 시간에 실행되지 않은 작업 알림

---

## 통합 효과

### Before (FastAPI Only)
```
[FastAPI] ✅ API 에러 추적
[Celery]  ❌ 백그라운드 작업 에러 미추적
```

### After (FastAPI + Celery)
```
[FastAPI] ✅ API 에러 추적
[Celery]  ✅ 백그라운드 작업 에러 추적
          ✅ End-to-End 분산 추적
```

---

## 사용 예시

### 1. Celery Task 에러 발생 시
```python
# worker/tasks/tickets/task_complete_ticket.py
@shared_task(name=COMPLETE_TICKET_TASK_NAME)
def task_complete_ticket(ticket_id: str):
    # 에러 발생 시 자동으로 Sentry에 보고
    raise Exception("Database connection failed")
```

**Sentry 대시보드**:
- Issue 타입: `Exception`
- Task 이름: `bzero.worker.tasks.tickets.task_complete_ticket`
- 인자: `ticket_id="0193c123..."`
- 재시도 횟수: 3/3
- 실행 시간: 2.3초

### 2. End-to-End 추적
```
User Request → FastAPI → Celery Task

Sentry Trace:
├─ POST /api/v1/tickets (300ms)
│  ├─ PurchaseTicketUseCase (150ms)
│  └─ TaskScheduler.schedule_ticket_completion (5ms)
└─ task_complete_ticket (2.5s)
   ├─ Database Query (1.2s)
   └─ Update Ticket Status (800ms)
```

---

## Test Plan

- [ ] Celery Worker 실행 시 Sentry 초기화 확인
- [ ] Task에서 의도적으로 에러 발생 시 Sentry에 보고되는지 확인
- [ ] Sentry 대시보드에서 Task 상세 정보 확인
- [ ] Performance 탭에서 Task 실행 시간 추적 확인
- [ ] FastAPI → Celery 분산 추적 동작 확인

---

## 설정 참고

### 환경 변수 (동일)
```bash
# .env
SENTRY__DSN=https://...@sentry.io/...
SENTRY__ENVIRONMENT=production
SENTRY__TRACES_SAMPLE_RATE=0.1
```

FastAPI와 Celery Worker 모두 동일한 환경 변수 사용.

### 샘플링 비율
- **Production**: 0.1 (10% 샘플링)
  - FastAPI 트랜잭션: 10%
  - Celery 트랜잭션: 10%
  - End-to-End 트레이스: 자동 전파

---

## Related

- #153 (FastAPI Sentry 통합)

---

## 관련 문서

- [Sentry Celery Integration](https://docs.sentry.io/platforms/python/integrations/celery/)
- [Distributed Tracing](https://docs.sentry.io/platforms/python/distributed-tracing/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)